### PR TITLE
Changed input format of body field to 'filtered html' in teaser_embed migration

### DIFF
--- a/modules/teaser_embed/migrate/teaser_embed.inc
+++ b/modules/teaser_embed/migrate/teaser_embed.inc
@@ -29,7 +29,7 @@ class TeaserEmbedDemoMigration extends TeaserDemoMigration {
     $this->addFieldMapping('title', 'title');
 
     $this->addFieldMapping('body', 'body');
-    $this->addFieldMapping('body:format')->defaultValue('full_html');
+    $this->addFieldMapping('body:format')->defaultValue('filtered_html');
 
     // Author, default to admin
     $this->addFieldMapping('uid')->defaultValue(1);

--- a/modules/teaser_embed/teaser_embed.info
+++ b/modules/teaser_embed/teaser_embed.info
@@ -1,7 +1,6 @@
 name = Teaser Embed
 core = 7.x
 package = Teaser
-dependencies[] = cine_fields
 dependencies[] = ctools
 dependencies[] = features
 dependencies[] = strongarm

--- a/modules/teaser_facebook/teaser_facebook.info
+++ b/modules/teaser_facebook/teaser_facebook.info
@@ -2,7 +2,6 @@ name = Teaser Facebook
 description = Create facebook page teasers
 core = 7.x
 package = Teaser
-dependencies[] = cine_fields
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = fb_likebox

--- a/modules/teaser_quote/teaser_quote.info
+++ b/modules/teaser_quote/teaser_quote.info
@@ -1,7 +1,6 @@
 name = Teaser Quote
 core = 7.x
 package = Teaser
-dependencies[] = cine_fields
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = features

--- a/modules/teaser_standard/teaser_standard.info
+++ b/modules/teaser_standard/teaser_standard.info
@@ -2,7 +2,6 @@ name = Teaser Standard
 core = 7.x
 package = Teaser
 dependencies[] = atom_reference
-dependencies[] = cine_fields
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = entityreference

--- a/modules/teaser_twitter/teaser_twitter.info
+++ b/modules/teaser_twitter/teaser_twitter.info
@@ -2,7 +2,6 @@ name = Teaser Twitter
 description = Twitter teaser content type
 core = 7.x
 package = Teaser
-dependencies[] = cine_fields
 dependencies[] = ctools
 dependencies[] = ds
 dependencies[] = features


### PR DESCRIPTION
ASF uses the CKEditor profile from foundation which configures CKE for the 'filtered html' input format only. If a body field is set to 'full html' like in the teaser embed migration, the form breaks with a JS error.