### PR TITLE
ASF-836 Fix default language

### DIFF
--- a/teaser.module
+++ b/teaser.module
@@ -58,11 +58,14 @@ function teaser_form_node_form_alter(&$form, $form_state) {
  * After build function
  */
 function teaser_node_form_after_build($form, $form_state) {
-  global $language;
-
   // When adding new teaser nodes, set default language to the current language
   if ($form['#node_edit_form'] && teaser_is_teaser($form['type']['#value']) && !isset($form['nid']['#value'])) {
-    $language_to_set = $language->language;
+    if (!empty($GLOBALS['language_url'])) {
+      $language_to_set = $GLOBALS['language_url']->language;
+    }
+    else {
+      $language_to_set = $GLOBALS['language']->language;
+    }
     $form['language']['#default_value'] = $language_to_set;
     $form['language']['#value'] = $language_to_set;
 


### PR DESCRIPTION
ASF use admin language, so the language gets incorrectly set to English for new teasers.

Work around this by first checking the language from the URL, and fallback to the global language is there's no match.