### PR TITLE
Add not_null to primary key on migrations

### DIFF
--- a/modules/teaser_facebook/migrate/teaser_facebook.inc
+++ b/modules/teaser_facebook/migrate/teaser_facebook.inc
@@ -12,6 +12,7 @@ class TeaserFacebookDemoMigration extends TeaserDemoMigration {
         'id' => array(
           'type' => 'varchar',
           'length' => 255,
+          'not null' => TRUE,
         ),
       ),
       MigrateDestinationNode::getKeySchema()

--- a/modules/teaser_quote/migrate/teaser_quote.inc
+++ b/modules/teaser_quote/migrate/teaser_quote.inc
@@ -12,6 +12,7 @@ class TeaserQuoteDemoMigration extends TeaserDemoMigration {
         'id' => array(
           'type' => 'varchar',
           'length' => 255,
+          'not null' => TRUE,
         ),
       ),
       MigrateDestinationNode::getKeySchema()

--- a/modules/teaser_standard/migrate/teaser_standard.inc
+++ b/modules/teaser_standard/migrate/teaser_standard.inc
@@ -12,6 +12,7 @@ class TeaserStandardDemoMigration extends TeaserDemoMigration {
         'id' => array(
           'type' => 'varchar',
           'length' => 255,
+          'not null' => TRUE,
         ),
       ),
       MigrateDestinationNode::getKeySchema()

--- a/modules/teaser_twitter/migrate/teaser_twitter.inc
+++ b/modules/teaser_twitter/migrate/teaser_twitter.inc
@@ -12,6 +12,7 @@ class TeaserTwitterDemoMigration extends TeaserDemoMigration {
         'id' => array(
           'type' => 'varchar',
           'length' => 255,
+          'not null' => TRUE,
         ),
       ),
       MigrateDestinationNode::getKeySchema()


### PR DESCRIPTION
On MySQL >= 5.7 the migrations cannot be constructed properly because the primary key on each map supports a NULL value. This PR enforces the use of `not_null`.